### PR TITLE
Adding packs_base_paths support to the st2.conf file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,3 +37,5 @@ st2_stanley_ssh_private_key: "-----BEGIN RSA PRIVATE KEY-----xxx"
 st2_stanley_ssh_public_key: "AAAAB"
 st2_stanley_username: 'deploy'
 st2_system_user: 'deploy'
+
+st2_packs_base_paths: ''

--- a/templates/st2.conf.j2
+++ b/templates/st2.conf.j2
@@ -69,3 +69,11 @@ logging = /etc/st2actions/syslog.notifier.conf
 
 [garbagecollector]
 logging = /etc/st2reactor/syslog.garbagecollector.conf
+
+[content]
+# Path to the directory which contains system packs.
+system_packs_base_path = /opt/stackstorm/packs
+{% if st2_packs_base_paths -%}
+# Paths which will be searched for integration packs.
+packs_base_paths = {{st2_packs_base_paths}}
+{% endif %}


### PR DESCRIPTION
This doesn't change anything by default, but for Omnia use, setting this allows us to define additional paths to packs.

```
st2_packs_base_paths: '/opt/omnia/infrastructure/packs'
```
