### PR TITLE
Update Stackstorm 1.3 AIO installer script URL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,3 +39,5 @@ st2_stanley_username: 'deploy'
 st2_system_user: 'deploy'
 
 st2_packs_base_paths: ''
+
+st2_aio_url: 'https://raw.githubusercontent.com/StackStorm/st2workroom/ce8dbb424bfbe58224fde44217eb0dd4ade1aa25/script/bootstrap-st2'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: get install script
   get_url:
-    url: 'http://stackstorm.com/install.sh'
+    url: "{{st2_aio_url}}"
     dest: "{{st2_install_script_path}}"
 
 - include: configure.yml


### PR DESCRIPTION
Stackstorm dropped their installer script and put up an "Update now!" alert. This PR updates the URL with a direct URL to the working script. I confirmed it worked on a client installation.
